### PR TITLE
Copy full playlist on longpress

### DIFF
--- a/app/src/main/java/com/watea/radio_upnp/activity/PlayerController.java
+++ b/app/src/main/java/com/watea/radio_upnp/activity/PlayerController.java
@@ -55,6 +55,8 @@ import com.watea.radio_upnp.service.RadioService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 
 public class PlayerController {
   private static final String LOG_TAG = PlayerController.class.getSimpleName();
@@ -255,6 +257,25 @@ public class PlayerController {
     playlistAlertDialog = new AlertDialog.Builder(mainActivity)
       .setAdapter(playlistAdapter, null)
       .create();
+      playlistAlertDialog.getListView().setOnItemLongClickListener((parent, itemView, position, id) -> {
+        // Concatenate all entries from the playlist
+        String allInformation = playInformations.stream()
+                                  .map(item -> item.get(RadioService.INFORMATION))
+                                  .collect(Collectors.joining("\n\n"));
+    
+        // Copy the concatenated information to clipboard
+        ClipboardManager clipboard = (ClipboardManager) mainActivity.getSystemService(Context.CLIPBOARD_SERVICE);
+        clipboard.setPrimaryClip(ClipData.newPlainText(mainActivity.getString(R.string.key_radio_information), allInformation.toString()));
+    
+        // Display a toast message to inform the user
+        mainActivity.tell(R.string.copied_playlist_to_clipboard);
+    
+        // Dismiss the dialog after handling the long press
+        playlistAlertDialog.dismiss();
+        return true; // Indicate that the long press was handled
+    });
+    
+        
     playlistAlertDialog.getListView().setOnItemClickListener((parent, rowView, position, id) -> {
       // Get the selected item from the playlist
       final Map<String, String> selectedItem = playInformations.get(position);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="play_long_press">Long press stops radio</string>
     <string name="toolbar_press">Touch on toolbar toggles expanded/reduced view</string>
     <string name="information_press">Click on playing radio icon to display current playlist</string>
-    <string name="information_select_press">Click on song to copy information to clipboard</string>
+    <string name="information_select_press">Click or long press song to copy song or whole list information to clipboard</string>
     <string name="dlna_enable">Short or Long press: search UPnP/DLNA devices.\n\nConnection may need connection authorization.\nBad Wifi may hinder connection quality.</string>
     <string name="preferred_radios">Display only preferred radios.\nPreferred radios are set in Modify screen.</string>
     <string name="wait_search">Search in progress.\nMay take some time, please wait&#8230;</string>
@@ -144,4 +144,5 @@
     <string name="dark_radio_button">Dark</string>
     <string name="light_radio_button">Light</string>
     <string name="copied_to_clipboard">Information copied to clipboard!</string>
+    <string name="copied_playlist_to_clipboard">Playlist copied to clipboard!</string>
 </resources>


### PR DESCRIPTION
Added longpress on playlist to copy full playlist to clipboard with entries separated by blank line similar to the display.